### PR TITLE
fix: export CI in builder stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ ARG CONTAINER_VERSION=13.3
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 FROM node:20-bookworm AS builder
 
+ENV CI=true
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl python3 make g++ \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- export `CI=true` inside the builder stage so pnpm treats the Docker build as CI
- this prevents pnpm from aborting while removing node_modules when no TTY is present

Fixes #8

## Testing
- curl -sSfL https://raw.githubusercontent.com/gautada/cicd/main/bin/pre-commit | bash
