### PR TITLE
Fix CI build: pnpm CI env, correct dist path, node_modules linker, appversion check

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -79,8 +79,8 @@ RUN /usr/sbin/usermod -l $USER debian \
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb dist and production node_modules from the build stage.
+COPY --from=builder /build/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
-COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,8 @@ ARG CONTAINER_VERSION=13.3
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 FROM node:20-bookworm AS builder
 
-ENV CI=true
+ENV CI=true \
+    PNPM_NODE_LINKER=node-modules
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl python3 make g++ \
@@ -78,9 +79,9 @@ RUN /usr/sbin/usermod -l $USER debian \
 # ╭――――――――――――――――――――╮
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
-# Copy the built nocodb dist and production node_modules from the build stage.
-COPY --from=builder /build/node_modules /usr/app/node_modules
+# Copy the built nocodb docker bundle and production node_modules from the build stage.
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
+COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/latest.sh
+++ b/latest.sh
@@ -1,16 +1,35 @@
 #!/bin/sh
 #
 # Fetches the latest stable NocoDB release version from GitHub.
-# Strips the leading 'v' prefix and any whitespace.
-# Returns non-zero if the API call fails or returns no tag.
+# Prefers the version recorded in packages/nocodb/package.json for that tag,
+# falling back to the tag name if the package manifest cannot be read.
+# Strips any leading 'v' prefix and whitespace from the final result.
 
-LATEST=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/releases/latest" \
-         | jq -r '.tag_name' \
-         | sed 's/^v//' \
-         | tr -d '[:space:]')
+set -eu
 
-if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
-  echo "Failed to retrieve latest NocoDB release version" >&2
+RELEASE_API="https://api.github.com/repos/nocodb/nocodb/releases/latest"
+TAG=$(curl -sL "$RELEASE_API" | jq -r '.tag_name' | tr -d '[:space:]')
+
+if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+  echo "Failed to retrieve latest NocoDB release tag" >&2
+  exit 1
+fi
+
+PACKAGE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/nocodb/nocodb/${TAG}/packages/nocodb/package.json" \
+  | jq -r '.version' \
+  | tr -d '[:space:]' \
+  || true)
+
+if [ -n "$PACKAGE_VERSION" ] && [ "$PACKAGE_VERSION" != "null" ]; then
+  LATEST=$PACKAGE_VERSION
+else
+  LATEST=$(printf '%s' "$TAG" | sed 's/^v//')
+fi
+
+LATEST=$(printf '%s' "$LATEST" | tr -d '[:space:]')
+
+if [ -z "$LATEST" ]; then
+  echo "Failed to determine latest NocoDB release version" >&2
   exit 1
 fi
 


### PR DESCRIPTION
References #8

Fixes the multi-arch container build failures caused by:
- pnpm requiring CI=true env in Docker build context
- Runtime stage copying incorrect dist path (packages/nocodb/dist → packages/nocodb/docker)
- pnpm hoisting causing missing xlsx dependency in final image
- appversion-check mismatching tag string vs package.json version