### PR TITLE
v2026.3.6

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -79,8 +79,8 @@ RUN /usr/sbin/usermod -l $USER debian \
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb dist and production node_modules from the build stage.
+COPY --from=builder /build/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
-COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ ARG CONTAINER_VERSION=13.3
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 FROM node:20-bookworm AS builder
 
+ENV CI=true
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl python3 make g++ \
  && rm -rf /var/lib/apt/lists/*

--- a/Containerfile
+++ b/Containerfile
@@ -80,7 +80,7 @@ RUN /usr/sbin/usermod -l $USER debian \
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb docker bundle and production node_modules from the build stage.
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
-COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
+COPY --from=builder /build/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/Containerfile
+++ b/Containerfile
@@ -10,8 +10,7 @@ ARG CONTAINER_VERSION=13.3
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 FROM node:20-bookworm AS builder
 
-ENV CI=true \
-    PNPM_NODE_LINKER=node-modules
+ENV CI=true
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl python3 make g++ \
@@ -37,7 +36,7 @@ RUN IMAGE_VERSION=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/release
 RUN pnpm install --frozen-lockfile \
  && pnpm --filter nocodb-sdk build \
  && pnpm --filter nocodb build \
- && pnpm --filter nocodb install --prod --ignore-scripts \
+ && pnpm deploy --filter nocodb --prod /deploy \
  && test -f /build/packages/nocodb/docker/main.js
 
 # ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
@@ -80,8 +79,9 @@ RUN /usr/sbin/usermod -l $USER debian \
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb docker bundle and production node_modules from the build stage.
+# /deploy is created by `pnpm deploy` and contains a flat, self-contained node_modules.
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
-COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
+COPY --from=builder /deploy/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,8 @@ RUN IMAGE_VERSION=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/release
 RUN pnpm install --frozen-lockfile \
  && pnpm --filter nocodb-sdk build \
  && pnpm --filter nocodb build \
- && pnpm --filter nocodb install --prod --ignore-scripts
+ && pnpm --filter nocodb install --prod --ignore-scripts \
+ && test -f /build/packages/nocodb/docker/main.js
 
 # ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮
 # │ STAGE 2: Final container image                                           │
@@ -78,7 +79,7 @@ RUN /usr/sbin/usermod -l $USER debian \
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb dist and production node_modules from the build stage.
-COPY --from=builder /build/packages/nocodb/dist    /usr/app/dist
+COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
 COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 

--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,6 @@ RUN IMAGE_VERSION=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/release
 RUN pnpm install --frozen-lockfile \
  && pnpm --filter nocodb-sdk build \
  && pnpm --filter nocodb build \
- && pnpm --filter nocodb install --prod --ignore-scripts \
  && test -f /build/packages/nocodb/docker/main.js
 
 # ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮

--- a/Containerfile
+++ b/Containerfile
@@ -79,9 +79,8 @@ RUN /usr/sbin/usermod -l $USER debian \
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
 # Copy the built nocodb docker bundle and production node_modules from the build stage.
-# /deploy is created by `pnpm deploy` and contains a flat, self-contained node_modules.
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
-COPY --from=builder /deploy/node_modules /usr/app/node_modules
+COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,7 @@ RUN IMAGE_VERSION=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/release
 RUN pnpm install --frozen-lockfile \
  && pnpm --filter nocodb-sdk build \
  && pnpm --filter nocodb build \
- && pnpm deploy --filter nocodb --prod /deploy \
+ && pnpm --filter nocodb install --prod --ignore-scripts \
  && test -f /build/packages/nocodb/docker/main.js
 
 # ╭――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╮

--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,8 @@ ARG CONTAINER_VERSION=13.3
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 FROM node:20-bookworm AS builder
 
-ENV CI=true
+ENV CI=true \
+    PNPM_NODE_LINKER=node-modules
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends git jq curl python3 make g++ \
@@ -78,9 +79,9 @@ RUN /usr/sbin/usermod -l $USER debian \
 # ╭――――――――――――――――――――╮
 # │ APPLICATION        │
 # ╰――――――――――――――――――――╯
-# Copy the built nocodb dist and production node_modules from the build stage.
-COPY --from=builder /build/node_modules /usr/app/node_modules
+# Copy the built nocodb docker bundle and production node_modules from the build stage.
 COPY --from=builder /build/packages/nocodb/docker /usr/app/docker
+COPY --from=builder /build/packages/nocodb/node_modules /usr/app/node_modules
 COPY --from=builder /build/packages/nocodb/package.json /usr/app/package.json
 
 # Create data directory for SQLite default backend and set ownership.

--- a/latest.sh
+++ b/latest.sh
@@ -1,16 +1,35 @@
 #!/bin/sh
 #
 # Fetches the latest stable NocoDB release version from GitHub.
-# Strips the leading 'v' prefix and any whitespace.
-# Returns non-zero if the API call fails or returns no tag.
+# Prefers the version recorded in packages/nocodb/package.json for that tag,
+# falling back to the tag name if the package manifest cannot be read.
+# Strips any leading 'v' prefix and whitespace from the final result.
 
-LATEST=$(curl -sL "https://api.github.com/repos/nocodb/nocodb/releases/latest" \
-         | jq -r '.tag_name' \
-         | sed 's/^v//' \
-         | tr -d '[:space:]')
+set -eu
 
-if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
-  echo "Failed to retrieve latest NocoDB release version" >&2
+RELEASE_API="https://api.github.com/repos/nocodb/nocodb/releases/latest"
+TAG=$(curl -sL "$RELEASE_API" | jq -r '.tag_name' | tr -d '[:space:]')
+
+if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+  echo "Failed to retrieve latest NocoDB release tag" >&2
+  exit 1
+fi
+
+PACKAGE_VERSION=$(curl -fsSL "https://raw.githubusercontent.com/nocodb/nocodb/${TAG}/packages/nocodb/package.json" \
+  | jq -r '.version' \
+  | tr -d '[:space:]' \
+  || true)
+
+if [ -n "$PACKAGE_VERSION" ] && [ "$PACKAGE_VERSION" != "null" ]; then
+  LATEST=$PACKAGE_VERSION
+else
+  LATEST=$(printf '%s' "$TAG" | sed 's/^v//')
+fi
+
+LATEST=$(printf '%s' "$LATEST" | tr -d '[:space:]')
+
+if [ -z "$LATEST" ]; then
+  echo "Failed to determine latest NocoDB release version" >&2
   exit 1
 fi
 

--- a/nocodb-running.sh
+++ b/nocodb-running.sh
@@ -10,11 +10,11 @@ if [ -z "$HEALTH" ]; then
   exit 1
 fi
 
-STATUS=$(printf '%s' "$HEALTH" | jq -r '.status' 2>/dev/null)
+STATUS=$(printf '%s' "$HEALTH" | jq -r '.message // .status' 2>/dev/null | tr '[:upper:]' '[:lower:]')
 if [ "$STATUS" = "ok" ]; then
-  echo "nocodb-running: NocoDB is healthy (status=ok)"
+  echo "nocodb-running: NocoDB is healthy"
   exit 0
 fi
 
-echo "nocodb-running: NocoDB health check returned unexpected status: $HEALTH"
+echo "nocodb-running: NocoDB health check returned unexpected response: $HEALTH"
 exit 1

--- a/nocodb.s6
+++ b/nocodb.s6
@@ -5,4 +5,4 @@
 # In production, set NC_DB to a PostgreSQL or MySQL connection string.
 export NC_PORT=8080
 export NC_DB="${NC_DB:-}"
-exec node /usr/app/dist/index.js
+exec node /usr/app/docker/main.js


### PR DESCRIPTION
References #8

Release of fixes to the NocoDB Debian container build pipeline. Resolves multi-arch CI failures caused by pnpm TTY requirements and monorepo dependency packaging issues.